### PR TITLE
Check refresh token errors frontend backend

### DIFF
--- a/src/server/api.js
+++ b/src/server/api.js
@@ -18,6 +18,69 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+// auto-refresh access token on 401 and retry the original request
+let isRefreshing = false;
+let refreshSubscribers = [];
+
+function onRefreshed(newToken) {
+  refreshSubscribers.forEach((callback) => callback(newToken));
+  refreshSubscribers = [];
+}
+
+function addRefreshSubscriber(callback) {
+  refreshSubscribers.push(callback);
+}
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error?.config || {};
+
+    const status = error?.response?.status;
+    const isRefreshEndpoint = typeof originalRequest.url === "string" && originalRequest.url.includes("/refresh");
+
+    if (status === 401 && !originalRequest._retry && !isRefreshEndpoint) {
+      originalRequest._retry = true;
+
+      if (!isRefreshing) {
+        isRefreshing = true;
+        try {
+          const { data } = await api.post("/refresh");
+          const newToken = data?.accessToken;
+          if (newToken) {
+            localStorage.setItem("accessToken", newToken);
+            api.defaults.headers.common.Authorization = `Bearer ${newToken}`;
+          }
+          onRefreshed(newToken || null);
+        } catch (refreshError) {
+          onRefreshed(null);
+          isRefreshing = false;
+          refreshSubscribers = [];
+          localStorage.removeItem("accessToken");
+          localStorage.removeItem("user");
+          return Promise.reject(refreshError);
+        } finally {
+          isRefreshing = false;
+        }
+      }
+
+      return new Promise((resolve, reject) => {
+        addRefreshSubscriber((token) => {
+          if (!token) {
+            reject(error);
+            return;
+          }
+          originalRequest.headers = originalRequest.headers || {};
+          originalRequest.headers.Authorization = `Bearer ${token}`;
+          resolve(api(originalRequest));
+        });
+      });
+    }
+
+    return Promise.reject(error);
+  }
+);
+
 // book endpoints (export helpers used by slices)
 export const getAllBooks = () => getBooks.get("/getbooks");
 


### PR DESCRIPTION
Add Axios response interceptor to automatically refresh access tokens on 401 errors.

The frontend previously lacked an automatic mechanism to refresh access tokens, requiring manual handling of 401 errors in components. This interceptor centralizes the refresh logic, retries failed requests, and handles concurrent refresh attempts, improving user experience and session management.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ce4c291-b7d8-45e3-8c64-8d8f8e1d7720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ce4c291-b7d8-45e3-8c64-8d8f8e1d7720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

