### PR TITLE
Handle unauthorized dashboard access

### DIFF
--- a/src/server/api.js
+++ b/src/server/api.js
@@ -99,7 +99,13 @@ const createResponseInterceptor = (instance) => async (error) => {
     return new Promise((resolve, reject) => {
       addRefreshSubscriber((token) => {
         if (!token) return reject(error);
-        originalRequest.headers.Authorization = `Bearer ${token}`;
+        // Ensure the Authorization header is correctly set for Axios v1
+        if (originalRequest.headers && typeof originalRequest.headers.set === "function") {
+          originalRequest.headers.set("Authorization", `Bearer ${token}`);
+        } else {
+          originalRequest.headers = originalRequest.headers || {};
+          originalRequest.headers.Authorization = `Bearer ${token}`;
+        }
         resolve(instance(originalRequest));
       });
     });


### PR DESCRIPTION
Fix automatic token refresh by correctly setting the Authorization header in the Axios interceptor for retried requests.

The previous Axios interceptor for token refresh was failing to properly re-attach the new access token to the `originalRequest` before retrying, specifically when using Axios v1's `headers.set` method. This led to subsequent retries still receiving a 401 (Unauthorized) error instead of succeeding. The update ensures the header is set correctly, allowing the refresh flow to complete as intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-42e37da6-f58d-4d44-9b98-e2c0b7d4b468">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42e37da6-f58d-4d44-9b98-e2c0b7d4b468">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

