### PR TITLE
Fix auth api unauthorized error and improve frontend

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,23 +24,23 @@ function App() {
         <Route path='/forgot-password' element={<ForgotPassword />} />
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/admin-dashboard" element={
-          <ProtectedRoute>
+          <ProtectedRoute adminOnly>
           <AdminDashboard />
           </ProtectedRoute>
           } />
           <Route path="/browse" element={<BookGrid />} />
         <Route path="/book/:id/edit" element={
-          <ProtectedRoute>
+          <ProtectedRoute adminOnly>
             <AddBookForm mode='edit' />
           </ProtectedRoute>
         } />
         <Route path="/book/create" element={
-          <ProtectedRoute>
+          <ProtectedRoute adminOnly>
             <AddBookForm mode='create' />
           </ProtectedRoute>
         } />
         <Route path="/admin/reviews" element={
-          <ProtectedRoute>
+          <ProtectedRoute adminOnly>
             <AdminReviews />
           </ProtectedRoute>
         } />

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,22 +1,19 @@
 import { Navigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
-const ProtectedRoute = ({ children }) => {
+const ProtectedRoute = ({ children, adminOnly = false }) => {
   const { accessToken, user } = useSelector((state) => state.auth);
-  
-  // Check if user is authenticated
+
+  // Require authentication
   if (!accessToken || !user) {
-    // Redirect to login if not authenticated
     return <Navigate to="/login" replace />;
   }
-  
-  // Check if user is admin for admin routes
-  if (window.location.pathname.includes('/admin') && (user.role || '').toLowerCase() !== 'admin') {
-    // Redirect to home if not admin
+
+  // Require admin role when needed
+  if (adminOnly && (user.role || '').toLowerCase() !== 'admin') {
     return <Navigate to="/" replace />;
   }
-  
-  // Render the protected content
+
   return children;
 };
 

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -59,6 +59,18 @@ const createResponseInterceptor = (instance) => async (error) => {
   const status = response.status;
   const isRefreshEndpoint = originalRequest.url?.includes("/refresh");
 
+  // Handle Forbidden immediately by clearing auth and redirecting
+  if (status === 403) {
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("user");
+    try {
+      if (window?.location?.pathname !== "/login") {
+        window.location.replace('/login');
+      }
+    } catch {}
+    return Promise.reject(error);
+  }
+
   if (status === 401 && !originalRequest._retry && !isRefreshEndpoint) {
     originalRequest._retry = true;
 
@@ -90,6 +102,11 @@ const createResponseInterceptor = (instance) => async (error) => {
         localStorage.removeItem("accessToken");
         localStorage.removeItem("user");
         window.dispatchEvent(new Event('storage'));
+        try {
+          if (window?.location?.pathname !== "/login") {
+            window.location.replace('/login');
+          }
+        } catch {}
         return Promise.reject(refreshError);
       } finally {
         isRefreshing = false;


### PR DESCRIPTION
Harden admin route protection and improve 401/403 error handling in the Axios interceptor to prevent unauthorized access and provide clearer feedback.

The `PUT /api/auth/:id` endpoint requires an admin role. Previously, non-admin users could reach these routes, leading to 401/403 errors. This PR introduces an `adminOnly` prop for `ProtectedRoute` to restrict access to admin pages, and enhances the Axios interceptor to gracefully handle 401 (failed refresh) and 403 (forbidden) responses by clearing authentication state and redirecting to the login page.

---
<a href="https://cursor.com/background-agent?bcId=bc-6003a27f-1ea6-4c50-8121-eae205452643">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6003a27f-1ea6-4c50-8121-eae205452643">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

